### PR TITLE
解决"this.currentNode.parent"可能为null的问题

### DIFF
--- a/lib/crawler/crawler.js
+++ b/lib/crawler/crawler.js
@@ -335,7 +335,9 @@ NSCrawler.prototype.insertTabNode = function (rawElement) {
     }
 
     node.parent = this.currentNode.parent;
-    node.reportSuite = node.parent.reportSuite;
+    if (node.parent && node.parent.reportSuite) {
+      node.reportSuite = node.parent.reportSuite;
+    }
     this.currentNode.parent = node;
     this.crawlingBuffer.push(node);
   }


### PR DESCRIPTION
this.currentNode.parent为null时，会报错如下：
`UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'reportSuite' of null`
