### PR TITLE
fix no such file or directory

### DIFF
--- a/lib/server/router.js
+++ b/lib/server/router.js
@@ -80,7 +80,7 @@ module.exports = function(app) {
   });
 
   rootRouter.get('/:report/:resource', function *(next) {
-    this.body = fs.readFileSync(path.join('.', 'reports', this.originalUrl));
+    this.body = fs.readFileSync(path.join(process.cwd(), 'reports', root.crawlingDateStamp, this.originalUrl));
     this.type = 'image/png';
     yield next;
   });


### PR DESCRIPTION
when I use nosmoke to run crawler in my Mac, I get some error as below
```
  <-- GET /screenshots/954e4295-7fc0-49c5-914d-d9233487bc40_0.png

  Error: ENOENT: no such file or directory, open 'reports/screenshots/954e4295-7fc0-49c5-914d-d9233487bc40_0.png'
```
as printed by the console, the `relative path` of  the screenshots is not incorrect, so I just use absolute path instead