### PR TITLE
judge log

### DIFF
--- a/lib/crawler/ocr-impl/ocr-crawler.js
+++ b/lib/crawler/ocr-impl/ocr-crawler.js
@@ -460,7 +460,9 @@ NSCrawler.prototype.refreshScreen = function (currentAction) {
                 .invert()
                 .write(filePath);
               setTimeout(() => {
-                console.log(`file generated with error: ${JSON.stringify(error)} at path: ${filePath}`);
+                if(error){
+                  console.log(`file generated with error: ${JSON.stringify(error)} at path: ${filePath}`);
+                }
                 tick('refresh screen image ready');
                 resolve(filePath);
               }, 400);

--- a/lib/crawler/ocr-impl/ocr-crawler.js
+++ b/lib/crawler/ocr-impl/ocr-crawler.js
@@ -460,7 +460,7 @@ NSCrawler.prototype.refreshScreen = function (currentAction) {
                 .invert()
                 .write(filePath);
               setTimeout(() => {
-                if(error){
+                if (error) {
                   console.log(`file generated with error: ${JSON.stringify(error)} at path: ${filePath}`);
                 }
                 tick('refresh screen image ready');


### PR DESCRIPTION
when I use nosmoke to run crawler in my Mac, I get some log as below
```
=======> event ---------- refresh screen starts:  1551061344
=======> event refresh screen recieving data:  1551061345
ocr-crawler file generated with error: null at path: ...
```
the line 
**ocr-crawler file generated with error: null at path**
is strange, because there is no error actually。
In face, it can not cause error, at the same time, maybe you just should see it when the error is real.
just a suggestion.