### PR TITLE
remove ocr text blank

### DIFF
--- a/lib/crawler/ocr-impl/ocr-crawler.js
+++ b/lib/crawler/ocr-impl/ocr-crawler.js
@@ -411,14 +411,16 @@ NSCrawler.prototype.checkShouldBeExcluded = function (excludedList, word) {
     return true;
   }
 
+  var wordName = word.name.toLowerCase().replace(/\s+/g, '');
+
   // check if word is one of the components in list, if so directly mark as need to be excluded.
-  var shouldBeExcluded = excludedList.indexOf(word.name) !== -1;
+  var shouldBeExcluded = excludedList.indexOf(wordName) !== -1;
 
   // check if the word is a substring of the excluding word, or the excluding word is part of the word.
   if (!shouldBeExcluded) {
     for (let i = 0; i < excludedList.length; i++) {
       let pattern = excludedList[i];
-      if (pattern.toLowerCase().includes(word.name.toLowerCase()) || word.name.toLowerCase().includes(pattern.toLowerCase())) {
+      if (pattern.toLowerCase().includes(wordName) || wordName.includes(pattern.toLowerCase())) {
         shouldBeExcluded = true;
         break;
       }

--- a/lib/crawler/ocr-impl/ocr-crawler.js
+++ b/lib/crawler/ocr-impl/ocr-crawler.js
@@ -289,7 +289,7 @@ NSCrawler.prototype.performAction = async function(actions) {
   tick('perform action finish');
 };
 
-NSCrawler.prototype.recursiveFilter = function (source, matches, exclusive) {
+NSCrawler.prototype.recursiveFilter = function (source, matches) {
 
   let prioritisedAction = [];
   let normalAction = [];
@@ -317,7 +317,7 @@ NSCrawler.prototype.recursiveFilter = function (source, matches, exclusive) {
         let word = currentLine.words[wordIndex];
         if (word.bbox.x0 / DPTOPXRatio - (currentWord.location.origin.x + currentWord.location.size.w) > maxTextSpacingInDP) {
           if (currentWord.location.origin.x > 0) {
-            if (!this.checkShouldBeExcluded(this.config.exclusivePattern, currentWord)) {
+            if (!this.checkShouldBeExcluded(this.config.exclude, currentWord)) {
               normalAction.push(currentWord);
               this.checkContentMatch(matches, currentWord, prioritisedAction);
               console.log(`filtering out action: ${JSON.stringify(currentWord)}`);

--- a/test/ocr-crawler.test.js
+++ b/test/ocr-crawler.test.js
@@ -1,0 +1,37 @@
+/* global describe it */
+
+'use strict';
+
+const assert = require('assert');
+const checkShouldBeExcluded = require('../lib/crawler/ocr-impl/ocr-crawler').NSCrawler.prototype.checkShouldBeExcluded;
+
+describe('#Check checkShouldBeExcluded', function() {
+  it('include', function() {
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'ma'}), true);
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'ca'}), true);
+  });
+
+  it('be included', function() {
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'macaca'}), true);
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'macacajs'}), true);
+  });
+
+  it('case insensitive', function() {
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'cA'}), true);
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'CA'}), true);
+    assert.equal(checkShouldBeExcluded(['ma', 'ca'], {name: 'Macacajs'}), true);
+  });
+
+  it('contain blank', function() {
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: '银 弹'}), true);
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: ' 银银 弹 '}), true);
+  });
+
+  it('some false', function() {
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: 'reporter'}), false);
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: 'wd'}), false);
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: 'inspector'}), false);
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: '硬'}), false);
+    assert.equal(checkShouldBeExcluded(['ma', '银弹'], {name: '核'}), false);
+  });
+});


### PR DESCRIPTION
When I set `exclude` with `性别`， It doesn't work because the `tesseract` identify it as `性 别` which has one more blank. So, I just remove all blanks and add some test cases to check.